### PR TITLE
storybook: Add missing inputs to documentation

### DIFF
--- a/projects/lunaui-angular/src/lib/buttons/icon-button/icon-button.stories.ts
+++ b/projects/lunaui-angular/src/lib/buttons/icon-button/icon-button.stories.ts
@@ -44,11 +44,7 @@ import { LunaIconButtonComponent } from '@lunaui/angular';
 \`\`\`
 
 \`\`\`html
-<luna-icon-button
-  [size]="'medium'"
-  [disabled]="false"
-  [variant]="'filled'"
-  (onClick)="onClick($event)">
+<luna-icon-button>
     <svg
       #icon fill="none" viewBox="0 0 24 24"
       stroke-width="1.5" stroke="currentColor"
@@ -76,7 +72,7 @@ import { LunaIconButtonComponent } from '@lunaui/angular';
       }
     },
     size: {
-      name: 'Size',
+      name: 'size',
       options: ['small', 'medium', 'large'],
       control: { type: 'select' },
       description: 'The size of the button',
@@ -88,20 +84,8 @@ import { LunaIconButtonComponent } from '@lunaui/angular';
         }
       }
     },
-    disabled: {
-      name: 'Disabled',
-      control: { type: 'boolean' },
-      description: 'Whether the button is disabled',
-      table: {
-        defaultValue: { summary: 'false' },
-        category: 'Inputs',
-        type: {
-          summary: 'boolean'
-        }
-      },
-    },
     variant: {
-      name: 'Variant',
+      name: 'variant',
       options: ['filled', 'tonal', 'outlined', 'text', 'elevated'],
       control: "select",
       description: 'The variant of the button',
@@ -113,8 +97,20 @@ import { LunaIconButtonComponent } from '@lunaui/angular';
         }
       }
     },
+    disabled: {
+      name: 'disabled',
+      control: { type: 'boolean' },
+      description: 'Whether the button is disabled',
+      table: {
+        defaultValue: { summary: 'false' },
+        category: 'Inputs',
+        type: {
+          summary: 'boolean'
+        }
+      },
+    },
     styles: {
-      name: 'Styles',
+      name: 'styles',
       control: 'object',
       description: 'The styles to apply to the button',
       table: {
@@ -122,6 +118,105 @@ import { LunaIconButtonComponent } from '@lunaui/angular';
         category: 'Inputs',
         type: {
           summary: 'Record<string, string>'
+        }
+      }
+    },
+    ariaLabel: {
+      name: 'ariaLabel',
+      description: 'The aria label of the button',
+      table: {
+        defaultValue: { summary: '' },
+        category: 'Inputs',
+        type: {
+          summary: 'string'
+        }
+      }
+    },
+    ariaLive: {
+      name: 'ariaLive',
+      description: 'The aria live of the button',
+      table: {
+        defaultValue: { summary: '' },
+        category: 'Inputs',
+        type: {
+          summary: 'off | polite | assertive | '
+        }
+      }
+    },
+    ariaDescribedBy: {
+      name: 'ariaDescribedBy',
+      description: 'The aria described by of the button',
+      table: {
+        defaultValue: { summary: '' },
+        category: 'Inputs',
+        type: {
+          summary: 'string'
+        }
+      }
+    },
+    type: {
+      name: 'type',
+      description: 'The type of the button',
+      table: {
+        defaultValue: { summary: 'button' },
+        category: 'Inputs',
+        type: {
+          summary: 'button | submit | reset'
+        }
+      }
+    },
+    form: {
+      name: 'form',
+      description: 'The form id linked with this button',
+      table: {
+        defaultValue: { summary: '' },
+        category: 'Inputs',
+        type: {
+          summary: 'string'
+        }
+      }
+    },
+    name: {
+      name: 'name',
+      description: 'The name of the button',
+      table: {
+        defaultValue: { summary: '' },
+        category: 'Inputs',
+        type: {
+          summary: 'string'
+        }
+      }
+    },
+    popovertarget: {
+      name: 'popovertarget',
+      description: 'The popover target of the button',
+      table: {
+        defaultValue: { summary: '' },
+        category: 'Inputs',
+        type: {
+          summary: 'string'
+        }
+      }
+    },
+    popovertargetaction: {
+      name: 'popovertargetaction',
+      description: 'The popover target action of the button',
+      table: {
+        defaultValue: { summary: 'null' },
+        category: 'Inputs',
+        type: {
+          summary: 'hide | show | toggle | null'
+        }
+      }
+    },
+    className: {
+      name: 'className',
+      description: 'The class name of the button',
+      table: {
+        defaultValue: { summary: '' },
+        category: 'Inputs',
+        type: {
+          summary: 'string'
         }
       }
     },
@@ -178,6 +273,9 @@ import { LunaIconButtonComponent } from '@lunaui/angular';
           [disabled]="disabled"
           [variant]="variant"
           [styles]="styles"
+          (onClick)="onClick($event)"
+          (focus)="focus($event)"
+          (blur)="blur($event)"
         >
           <svg
             #icon


### PR DESCRIPTION
Add component inputs documentation: 

- ariaLabel
- ariaLive
- ariaDescribedBy
- type
- form
- name
- popovertarget
- popovertargetaction
- classname
